### PR TITLE
Get ready for publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-secrets-gcp",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-secrets-gcp",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Fastify secrets plugin for Google cloud platform secrets manager",
   "main": "lib/fastify-secrets-gcp.js",
   "scripts": {


### PR DESCRIPTION
- use latest `fastify-secrets-core`
- bump to version 1.0.0