### PR TITLE
chore: run automerge only on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,17 @@ jobs:
     steps:
       - name: Dependabot Auto Merge
         uses: actions/github-script@v3
-        if: ${{ github.actor == 'dependabot[bot]' }}
+        if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.github_token}}
           script: |
-            github.pulls.createReview({
+            await github.pulls.createReview({
               owner: context.payload.repository.owner.login,
               repo: context.payload.repository.name,
               pull_number: context.payload.pull_request.number,
               event: 'APPROVE'
             })
-            github.pulls.merge({
+            await github.pulls.merge({
               owner: context.payload.repository.owner.login,
               repo: context.payload.repository.name,
               pull_number: context.payload.pull_request.number


### PR DESCRIPTION
- Added a check in automerge job to make sure it only runs for PRs not for commits (to avoid the error `Unhandled error: TypeError: Cannot read property 'number' of undefined`)
- Added missing `await` to the PR approve and merge