### PR TITLE
docs: add minimum example for jest

### DIFF
--- a/examples/fastify-secrets-jest/.eslintrc.js
+++ b/examples/fastify-secrets-jest/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  globals: {
+    fastify: 'readonly'
+  },
+  env: {
+    'jest/globals': true,
+    commonjs: true,
+    es6: true,
+    node: true
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:node/recommended',
+    'plugin:jest/recommended'
+  ],
+  parserOptions: {
+    ecmaVersion: 2020
+  }
+}

--- a/examples/fastify-secrets-jest/.jest/fastify-env.js
+++ b/examples/fastify-secrets-jest/.jest/fastify-env.js
@@ -1,0 +1,16 @@
+const NodeEnvironment = require('jest-environment-node');
+const fastifyBuilder = require('../app')
+
+class FastifyEnvironment extends NodeEnvironment {
+  constructor(config, context) {
+    super(config, context);
+  }
+
+  async setup() {
+    await super.setup();
+    const fastify = await fastifyBuilder({});
+    this.global.fastify = fastify;
+  }
+}
+
+module.exports = FastifyEnvironment;

--- a/examples/fastify-secrets-jest/.prettierrc
+++ b/examples/fastify-secrets-jest/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "none"
+}

--- a/examples/fastify-secrets-jest/README.md
+++ b/examples/fastify-secrets-jest/README.md
@@ -1,0 +1,3 @@
+# GCP Secrets Manager with Fastify and Jest
+
+Minimal example with async plugin registration and jest environment.

--- a/examples/fastify-secrets-jest/app.js
+++ b/examples/fastify-secrets-jest/app.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const Fastify = require('fastify')
+const FastifySecrets = require('fastify-secrets-gcp')
+const { fromPairs } = require('lodash')
+
+async function build(opts = {}) {
+  const app = Fastify(opts)
+
+  const secrets = [
+    [
+      'api_auth0_client_secret',
+      'projects/xyz/secrets/API_AUTH0_CLIENT_SECRET/versions/latest'
+    ]
+  ]
+  await app.register(FastifySecrets, {
+    secrets: fromPairs(secrets)
+  })
+
+  app.register(require('fastify-auth0-verify'), {
+    domain: auth0.domain,
+    audience: auth0.audience,
+    secret: app.secrets.api_auth0_client_secret
+  })
+
+  app.get('/', function (request, reply) {
+    reply.send('I am happy and healthy\n')
+  })
+
+  return app
+}
+
+module.exports = build

--- a/examples/fastify-secrets-jest/index.js
+++ b/examples/fastify-secrets-jest/index.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const build = require('./app')
+
+const start = async () => {
+  try {
+    const fastify = await build({})
+    await fastify.listen(3001)
+  } catch (err) {
+    console.log(err)
+    process.exit(1)
+  }
+}
+
+start()

--- a/examples/fastify-secrets-jest/jest.config.js
+++ b/examples/fastify-secrets-jest/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: './.jest/fastify-env'
+};

--- a/examples/fastify-secrets-jest/package.json
+++ b/examples/fastify-secrets-jest/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "gs-poc",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "jest"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "fastify": "^3.19.1",
+    "fastify-auth0-verify": "^0.5.2",
+    "fastify-secrets-gcp": "^1.0.1",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "jest": "^27.0.6"
+  }
+}

--- a/examples/fastify-secrets-jest/test/get.test.js
+++ b/examples/fastify-secrets-jest/test/get.test.js
@@ -1,0 +1,14 @@
+afterAll(() => {
+  fastify.close()
+})
+
+describe('GET /', () => {
+  it('should return', async () => {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    expect(response.statusCode).toEqual(200)
+  })
+})


### PR DESCRIPTION
We had some issues retrieving secrets straight after registering this plugin because of the async nature and can't use top-level await just yet, so this example shows how to start the server in an async function and sets up a jest environment for tests.

Closes #137 