### PR TITLE
Revert "chore(deps-dev): bump eslint from 7.32.0 to 8.0.1 (#149)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">= 12.13.0"
   },
   "devDependencies": {
-    "eslint": "^8.0.1",
+    "eslint": "^7.11.0",
     "eslint-config-prettier": "^8.0.0",
     "eslint-config-standard": "^16.0.0",
     "eslint-plugin-import": "^2.22.1",


### PR DESCRIPTION
This reverts commit 890125699c95e46067dc699b6ffc0f7ab1756b0e.