### PR TITLE
feat: rethrow original error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -12,7 +12,7 @@ class GcpClient {
       const [version] = await this.sdk.accessSecretVersion({ name })
       return version.payload.data.toString('utf8')
     } catch (err) {
-      throw new Error(`Secret not found: ${name}`)
+      throw new Error(err)
     }
   }
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,12 +8,8 @@ class GcpClient {
   }
 
   async get(name) {
-    try {
-      const [version] = await this.sdk.accessSecretVersion({ name })
-      return version.payload.data.toString('utf8')
-    } catch (err) {
-      throw new Error(err)
-    }
+    const [version] = await this.sdk.accessSecretVersion({ name })
+    return version.payload.data.toString('utf8')
   }
 }
 


### PR DESCRIPTION
Just suggesting this change because what's thrown right now isn't very useful for figuring out what went wrong:
![image](https://github.com/nearform/fastify-secrets-gcp/assets/533052/03d443aa-66ca-40e5-97db-35ddfbe0c9aa)


But if we just re-throw the original error:
![image](https://github.com/nearform/fastify-secrets-gcp/assets/533052/9efb1a08-3a6f-446f-ac08-c116b7c34d95)

Now I know someone actually has a GCP project called "baby" but Secret Manager isn't enabled for it :slightly_smiling_face: 

Tests are passing because they assert only that an error is thrown.